### PR TITLE
Update 2021-09-20.scalibility.notify-short-code.md

### DIFF
--- a/records/2021-09-20.scalibility.notify-short-code.md
+++ b/records/2021-09-20.scalibility.notify-short-code.md
@@ -26,13 +26,13 @@ Notify is set up in two places. We have a random pool of numbers in CA-Central. 
 
 1. Short codes are supposed to be tied to a single service. [As can be seen from our application to AWS last year](https://docs.google.com/document/d/1IbBHE_hDtXmV03FJFeB5wRWUekzmEP4Ky2x0a_lDBtg/edit), we couldn't apply the short codes to every single service.
 1. Notify is the base service that is used by a multitude of governmental services. The unsubscribe feature is managed by AWS (If a customer responds to the short code with 'STOP', AWS puts the user on a do not send list). AWS allows us to remove a single user from the unsubscribe list once every 30 days. Eg: Immigration, Refugee and Citizenship Canada (IRCC) and Canadian Border Services Agency (CBSA) use Notify for different usecases. The same short-code would be used by both services. This leads to problems with subscriptions as an end user might chose to unsubscribe from notifications sent by IRCC but inadvertently blocks notifications sent by CBSA.
-1. We could potentially apply for a short code under the Government of Canada organization according to AWS. The templates we create for the short code should have the official Government of Canada header and footer. This might lend credibility to our application and give Notify leeway in terms of one-code for one service. Our ask would be to not see notify as a promotional service but as a Government of Canada essential service that operates under different rules.
+1. We could potentially apply for a short code under the Government of Canada organization according to AWS. The templates we create for the short code should have the official Government of Canada header and footer. This might lend credibility to our application and give Notify leeway in terms of one-code for one service. Our ask would be to not see Notify as a promotional service but as a Government of Canada essential service that operates under different rules.
 
 ### Cost of Short Codes
 
 Short codes are very expensive. As of Sept 2021, it is 3000 USD to setup and a 1000 USD in recurring monthly costs. It would be cost prohibitive to get short codes per service that use Notify. Notify cannot take that cost on a per service basis.
 
-Short codes also require paperword and 10-16 weeks to get processed. We do not have a self serve option for Notify clients to pick whether they want a Short Code or not. We would have to create a process that would inform individual services about the cost of obtaining a short code, as well as a process for application and applying the Short Code to our service.
+Short codes also require paperwork and 10-16 weeks to get processed. We do not have a self serve option for Notify clients to pick whether they want a Short Code or not. We would have to create a process that would inform individual services about the cost of obtaining a short code, as well as a process for application and applying the Short Code to our service.
 
 The short code usage is as following, compared to long code to provide a comparison:
 
@@ -41,7 +41,7 @@ The short code usage is as following, compared to long code to provide a compari
 | Base price  | 0.00581   | 0.02183    |
 | Carrier fee | 0.006     | 0.005      |
 
-The cost is higher per usage so we would need to thoroughly vet for official federal services that really need high throughput and a trusted short code number.
+The cost is higher per usage so we would need to thoroughly vet for official federal services that really need high throughput and a trusted Short Code number. We would not offer the Short Code for federal services that send SMS to internal government employees, only to those federal services that send SMS to the public.
 
 ### Increase Throughput
 
@@ -70,7 +70,7 @@ Instead of using short codes, we could opt for toll free numbers. Toll free numb
 
 ### Pool of Canadian numbers
 
-Another option could be to buy a pool of 100 Canadian numbers (or required numbers). These comes at a cost of 1 USD / month / number, costing much less than a short code. We would get a much higher rate by rotating through our own numbers and would have total control over these. There would be an application logic overhead that we would need to write, such as a round-robin strategy with certain range of  reserved numbers for service that require trust via dedicated long code.
+Another option could be to buy a pool of 100 Canadian numbers (or required numbers). These comes at a cost of 1 USD / month / number, costing much less than a Short Code. We would get a much higher rate by rotating through our own numbers and would have total control over these. There would be an application logic overhead that we would need to write, such as a round-robin strategy with certain range of reserved numbers for service that require trust via dedicated long code.
 
 We could host these either in the us-west-2 region or ca-central-1. It is worth to note that if we have dedicated region in an AWS region, we cannot use their random pool of numbers. At the moment, we have no dedicated numbers in ca-central-1 for that reason, falling back on AWS pool of long codes by default.
 
@@ -80,11 +80,13 @@ This is an avenue where we could support a short code associated to one and only
 
 Notify has no support for billing at the current time although there is GDS code present in its source code to support it.
 
+This option could be considered in the future for provincial or territorial government services who want their own Short Code.
+
 ## Decision
 
-We consider going forward with filling in an application for short code, considering that:
+We consider going forward with filling in an application for a Short Code, considering that:
 
-1. We can push forward our application by filing under the government of Canada organization and provide the most used services that would be candidates for that application as templates in the request.
-1. The request for a short code does not cost anything.
+1. We can push forward our application by filing under the Government of Canada organization and provide the most used services that would be candidates for that application as templates in the request.
+1. The request for a Short Code does not cost anything.
 1. The cutoff period for new request this year ends on October 28th. No new requests will be considered until new year. That means that if we do not request one in the upcoming days, it could take up to 6 months to get a short code (3 months to end of year + 3 months for the request processing).
 1. The issue around the STOP keyword (and a much needed unsubscribe option) is one that we already have with our current setup and hence, short code will not make it worst (nor improve it).


### PR DESCRIPTION
# Summary | Résumé

Updated a few lines to reflect some discussion with AWS
> Added that P/Ts would have to request to have their own Short Code
https://app.zenhub.com/workspaces/notify-planning-614b3ad91bc2030015ed22f5/issues/cds-snc/notification-planning/182

---

# Help requested | Aide requise

> Need to add more information about our options to manage STOP opt-outs with AWS as discussed in meeting with AWS SNS Product Manager



