### PR TITLE
docs: improve reliability of Notify service config

### DIFF
--- a/records/2022-03-23.deployment.lambda-api-environment-variables.md
+++ b/records/2022-03-23.deployment.lambda-api-environment-variables.md
@@ -4,7 +4,7 @@ Date: 2022-03-23
 
 ## Status
 
-**In review.**
+**Approved.**
 
 ## Context
 

--- a/records/2022-04-07.reliability.service.configuration.md
+++ b/records/2022-04-07.reliability.service.configuration.md
@@ -8,7 +8,7 @@ Date: 2022-04-07
 
 ## Context
 
-The Notify API, Admin and Document Download services are configured using environment variables.  These environment variables are stored in encrypted `.env` files and Kubernetes manifests.  Overtime, misconfigurations have occurred because of inconsistencies in how the String values of the environment variables are converted to Boolean and Integer values.  
+The Notify API, Admin and Document Download API are configured using environment variables.  These environment variables are stored in encrypted `.env` files and Kubernetes manifests.  Overtime, misconfigurations have occurred because of inconsistencies in how the String values of the environment variables are converted to Boolean and Integer values.  
 
 The goal of this solution is to improve the reliability of service configuration by consistently setting configuration values across services and logging the service configuration when it starts so that it can be validated. 
 
@@ -18,11 +18,11 @@ There are two proposed solutions for this ADR.
 
 ### Log configuration on service startup
 
-Update the Notify API, Admin and Document Download to log their configuration values on startup.  This will allow us to validate that the running services have the expected configuration values.  Sensitive values will be redacted in the logs to prevent accidental exposure.
+Update the Notify API, Admin and Document Download API to log their configuration values on startup.  This will allow us to validate that the running services have the expected configuration values.  Sensitive values will be redacted in the logs to prevent accidental exposure.
 
 ### Use `environs` Python package
 
-Update the Notify API, Admin and Document Download services to use the [`environs` Python package](https://pypi.org/project/environs/) to load Boolean and Integer configuration values.  By using `environs` we will be able to take advantage of their `env.bool` and `env.int` functions to consistently load configuration values with default fallbacks.  Currently there are multiple different ways being used to coerce String configuration values into Booleans and Integers, which is leading to mis-configuation. 
+Update the Notify API, Admin and Document Download API to use the [`environs` Python package](https://pypi.org/project/environs/) to load Boolean and Integer configuration values.  By using `environs` we will be able to take advantage of its `env.bool` and `env.int` functions to consistently load configuration values with default fallbacks.  Currently there are multiple different ways being used to coerce String configuration values into Booleans and Integers, which is leading to mis-configuation. 
 
 ## Testing
 

--- a/records/2022-04-07.reliability.service.configuration.md
+++ b/records/2022-04-07.reliability.service.configuration.md
@@ -22,7 +22,7 @@ Update the Notify API, Admin and Document Download API to log their configuratio
 
 ### Use `environs` Python package
 
-Update the Notify API, Admin and Document Download API to use the [`environs` Python package](https://pypi.org/project/environs/) to load Boolean and Integer configuration values.  By using `environs` we will be able to take advantage of its `env.bool` and `env.int` functions to consistently load configuration values with default fallbacks.  Currently there are multiple different ways being used to coerce String configuration values into Booleans and Integers, which is leading to mis-configuation. 
+Update the Notify API, Admin and Document Download API to use the [`environs` Python package](https://pypi.org/project/environs/) to load Boolean and Integer configuration values. By using `environs` we will be able to take advantage of its `env.bool` and `env.int` functions to consistently load configuration values with default fallbacks. Currently there are multiple different ways being used to coerce String configuration values into Booleans and Integers, which is leading to mis-configuation.
 
 ## Testing
 

--- a/records/2022-04-07.reliability.service.configuration.md
+++ b/records/2022-04-07.reliability.service.configuration.md
@@ -1,0 +1,36 @@
+# Improve Notify service configuration reliability
+
+Date: 2022-04-07
+
+## Status
+
+**In review.**
+
+## Context
+
+The Notify API, Admin and Document Download services are configured using environment variables.  These environment variables are stored in encrypted `.env` files and Kubernetes manifests.  Overtime, misconfigurations have occurred because of inconsistencies in how the String values of the environment variables are converted to Boolean and Integer values.  
+
+The goal of this solution is to improve the reliability of service configuration by consistently setting configuration values across services and logging the service configuration when it starts so that it can be validated. 
+
+## Proposed solution
+
+There are two proposed solutions for this ADR.
+
+### Log configuration on service startup
+
+Update the Notify API, Admin and Document Download to log their configuration values on startup.  This will allow us to validate that the running services have the expected configuration values.  Sensitive values will be redacted in the logs to prevent accidental exposure.
+
+### Use `environs` Python package
+
+Update the Notify API, Admin and Document Download services to use the [`environs` Python package](https://pypi.org/project/environs/) to load Boolean and Integer configuration values.  By using `environs` we will be able to take advantage of their `env.bool` and `env.int` functions to consistently load configuration values with default fallbacks.  Currently there are multiple different ways being used to coerce String configuration values into Booleans and Integers, which is leading to mis-configuation. 
+
+## Testing
+
+The logged output from the Notify services will be compared with the expected values in the encrypted `.env` files and Kubernetes manifests.
+
+## Additional considerations
+
+This proposal is related to the work being done in the following issues:
+- [cds-snc/notification-planning#421](https://github.com/cds-snc/notification-planning/issues/421)
+- [cds-snc/notification-planning#503](https://github.com/cds-snc/notification-planning/issues/503)
+- [cds-snc/notification-planning#504](https://github.com/cds-snc/notification-planning/issues/504)

--- a/records/2022-04-07.reliability.service.configuration.md
+++ b/records/2022-04-07.reliability.service.configuration.md
@@ -18,7 +18,7 @@ There are two proposed solutions for this ADR.
 
 ### Log configuration on service startup
 
-Update the Notify API, Admin and Document Download API to log their configuration values on startup.  This will allow us to validate that the running services have the expected configuration values.  Sensitive values will be redacted in the logs to prevent accidental exposure.
+Update the Notify API, Admin and Document Download API to log their configuration values on startup. This will allow us to validate that the running services have the expected configuration values. Sensitive values will be redacted in the logs to prevent accidental exposure.
 
 ### Use `environs` Python package
 

--- a/records/2022-04-07.reliability.service.configuration.md
+++ b/records/2022-04-07.reliability.service.configuration.md
@@ -4,7 +4,7 @@ Date: 2022-04-07
 
 ## Status
 
-**In review.**
+**Approved.**
 
 ## Context
 

--- a/records/2022-04-07.reliability.service.configuration.md
+++ b/records/2022-04-07.reliability.service.configuration.md
@@ -28,6 +28,13 @@ Update the Notify API, Admin and Document Download API to use the [`environs` Py
 
 The logged output from the Notify services will be compared with the expected values in the encrypted `.env` files and Kubernetes manifests.
 
+## Outcomes
+
+It is expected we will see the following with the proposed solutions:
+
+- [ ] Fewer incidents caused by misconfigurations of the Notify services.
+- [ ] A higher degree of confidence in the configuration values of the Notify services.
+
 ## Additional considerations
 
 This proposal is related to the work being done in the following issues:


### PR DESCRIPTION
# Summary

Describe the work done to improve the reliability of the Notify API, admin and
document download service configuration using environment variables.

Also marks the Lambda API env var ADR as `Approved`.

# Rendered content
https://github.com/cds-snc/notification-adr/blob/docs/reliability-service-config/records/2022-04-07.reliability.service.configuration.md

# Related
- cds-snc/notification-planning#421
- cds-snc/notification-planning#503
- cds-snc/notification-planning#504