### PR TITLE
Task/api token prefix

### DIFF
--- a/records/2022-07-20.security.prefix-api-token.md
+++ b/records/2022-07-20.security.prefix-api-token.md
@@ -24,7 +24,7 @@ By combining a known prefix with Github's [secret scanning program](https://docs
 ### Supporting older keys
 We want to be able to support previous API keys for a certain time period and there should be nothing additional we need to do for that (provided we dont remove old keys). But, in the future, we may want to enforce that all keys have the prefix after.
 
-In order to make this work we would need to communicate with existing users who have older keys and invalidating the keys once we know they have new ones.
+In order to make this work we would need to communicate with existing users who have older keys and then invalidate the keys once we know they have new ones.
 
 ### Verifying API keys
 Currently, API ignores everything but the right-most characters of an API key.  This will need to be updated in order to verify the existence of the prefix.

--- a/records/2022-07-20.security.prefix-api-token.md
+++ b/records/2022-07-20.security.prefix-api-token.md
@@ -1,4 +1,4 @@
-# TITLE
+# Prefixing of API tokens
 
 Date: 2022-07-20
 
@@ -10,25 +10,48 @@ Date: 2022-07-20
 
 The mishandling of application secrets has lead to many security incidents in companies big and small. Given the inherent risk in how users store these secrets, it is important that we provide mechanisms to protect our users from doing so improperly.  Taking a cue from [Github](https://github.blog/2021-04-05-behind-githubs-new-authentication-token-formats/), [Slack](https://api.slack.com/authentication/token-types), and [Stripe](https://stripe.com/docs/api/authentication), we see that token prefixes are an effective technique to help us ensure our tokens don't end up in public repositories.
 
-By combining a known prefix with Github's [secret scanning program](https://docs.github.com/en/developers/overview/secret-scanning-partner-program), we can be alerted if one of our users mistakenly stores their API keys in the open and we can take action.
+By combining a known prefix with initiatives such as Github's [secret scanning program](https://docs.github.com/en/developers/overview/secret-scanning-partner-program), we can be alerted if one of our users mistakenly stores their API keys in the open.
 
-## Options
+## Implementation steps
 
 - Add a known prefix to our API keys in order to be able to easily identify them
 - Register with Github's secret scanning program and create an endpoint for them to report issues back to us
 - Give users a grace period to generate new keys
   - After grace period, enforce a rule that ensures all API keys contain our prefix
 
+### Old API key deprecation process
+
+In order to deprecate old keys each user must be contacted to let them know they need to regenerate their keys and update their applications.  Until all users have regenerated their API keys, we can't start enforcing the existence of the prefix
+
+#### Process outline
+1. Contact clients with non-prefixed keys (based on key creation date); give them a deadline (TBD) and instructions on how to re-generate their API keys
+1. After deadline, re-check how many users still haven't re-generated their keys and contact a second time
+1. When all users have re-generated, or we are satisfied with the percentage of users who have, implement prefix checking in the API.
+
+
+## Implementation notes
+- API keys are stored in the table `api_keys`
+- API keys are stored using a name the user chooses (`name`) and a secret that we generate (`secret`)
+- We can store the new keys the same way without changing any database fields.
+- No changes are required to support old keys; instead, old keys will stop being supported as soon as we add validation to ensure keys contain our prefix. API ignores everything but the right-most characters of an API key.  This will need to be updated in order to verify the existence of the prefix.
+
 ## Additional considerations
 
-### Supporting older keys
-We want to be able to support previous API keys for a certain time period and there should be nothing additional we need to do for that (provided we dont remove old keys). But, in the future, we may want to enforce that all keys have the prefix after.
+### Client libraries
+Any changes to the API keys must be tested in all of the client libraries we support:
+- Java
+- .NET
+- NodeJS
+- PHP
+- Python
+- Ruby
 
-In order to make this work we would need to communicate with existing users who have older keys and then invalidate the keys once we know they have new ones.
-
-### Verifying API keys
-Currently, API ignores everything but the right-most characters of an API key.  This will need to be updated in order to verify the existence of the prefix.
-
+### Other open source platforms
+There are other open source platforms we may wish to monitor for keys as well, including, but not limited to:
+- GitLab
+- Bitbucket
+- Gitea
+- Google Cloud Source Repositories
 
 ## Decision
 

--- a/records/2022-07-20.security.prefix-api-token.md
+++ b/records/2022-07-20.security.prefix-api-token.md
@@ -12,7 +12,7 @@ The mishandling of application secrets has lead to many security incidents in co
 
 By combining a known prefix with initiatives such as Github's [secret scanning program](https://docs.github.com/en/developers/overview/secret-scanning-partner-program), we can be alerted if one of our users mistakenly stores their API keys in the open.
 
-## Implementation steps
+## Implementation overview
 
 - Add a known prefix to our API keys in order to be able to easily identify them
 - Register with Github's secret scanning program and create an endpoint for them to report issues back to us
@@ -29,11 +29,10 @@ In order to deprecate old keys each user must be contacted to let them know they
 1. When all users have re-generated, or we are satisfied with the percentage of users who have, implement prefix checking in the API.
 
 
-## Implementation notes
+## API and Admin implementation notes
 - API will be responsible to add the prefix and later to validate it:
    - On key creation: prefix entire token and return to admin
-   - On api requests: prefix validation (once we enable it)
-   - Note: the actual prefix value will not be stored in the database
+   - On api requests: validate the prefix exists (once we enable it)
 - Admin will provide api key details to the user:
   - On key creation: provide the prefixed key back to the user
 - No changes are required to continue to support old keys

--- a/records/2022-07-20.security.prefix-api-token.md
+++ b/records/2022-07-20.security.prefix-api-token.md
@@ -16,7 +16,7 @@ By combining a known prefix with Github's [secret scanning program](https://docs
 
 - Add a known prefix to our API keys in order to be able to easily identify them
 - Register with Github's secret scanning program and create an endpoint for them to report issues back to us
-- (optional) Give users a grace period to generate new keys
+- Give users a grace period to generate new keys
   - After grace period, enforce a rule that ensures all API keys contain our prefix
 
 ## Additional considerations

--- a/records/2022-07-20.security.prefix-api-token.md
+++ b/records/2022-07-20.security.prefix-api-token.md
@@ -14,11 +14,10 @@ By combining a known prefix with Github's [secret scanning program](https://docs
 
 ## Options
 
-- Add a known prefix to our API keys in order to be able to easily identify them.
+- Add a known prefix to our API keys in order to be able to easily identify them
 - Register with Github's secret scanning program and create an endpoint for them to report issues back to us
-
-### After grace period
-- Enforce a rule that ensures all API keys contain our prefix
+- (optional) Give users a grace period to generate new keys
+  - After grace period, enforce a rule that ensures all API keys contain our prefix
 
 ## Additional considerations
 

--- a/records/2022-07-20.security.prefix-api-token.md
+++ b/records/2022-07-20.security.prefix-api-token.md
@@ -30,10 +30,10 @@ In order to deprecate old keys each user must be contacted to let them know they
 
 
 ## Implementation notes
-- API keys are stored in the table `api_keys`
-- API keys are stored using a name the user chooses (`name`) and a secret that we generate (`secret`)
-- We can store the new keys the same way without changing any database fields.
-- No changes are required to support old keys; instead, old keys will stop being supported as soon as we add validation to ensure keys contain our prefix. API ignores everything but the right-most characters of an API key.  This will need to be updated in order to verify the existence of the prefix.
+- On key generation, the API will prefix the entire token and provide that back to admin
+- Admin will provide the prefixed key back to the user
+- No changes are required to support old keys
+- After grace period, validation will be implemented to ensure all keys used to call API contain the prefix value 
 
 ## Additional considerations
 

--- a/records/2022-07-20.security.prefix-api-token.md
+++ b/records/2022-07-20.security.prefix-api-token.md
@@ -22,7 +22,9 @@ By combining a known prefix with Github's [secret scanning program](https://docs
 ## Additional considerations
 
 ### Supporting older keys
-We want to be able to support previous API keys for a certain time period and there should be nothing additional we need to do for that (provided we dont remove old keys). But, in the future, we may want to enforce that all keys have the prefix after a certain time, i.e. within 6 months, 9 months, etc.  This would involve us enumerating old keys, contacting users and invalidating the keys once we know they have new ones.
+We want to be able to support previous API keys for a certain time period and there should be nothing additional we need to do for that (provided we dont remove old keys). But, in the future, we may want to enforce that all keys have the prefix after.
+
+In order to make this work we would need to communicate with existing users who have older keys and invalidating the keys once we know they have new ones.
 
 ### Verifying API keys
 Currently, API ignores everything but the right-most characters of an API key.  This will need to be updated in order to verify the existence of the prefix.

--- a/records/2022-07-20.security.prefix-api-token.md
+++ b/records/2022-07-20.security.prefix-api-token.md
@@ -30,9 +30,13 @@ In order to deprecate old keys each user must be contacted to let them know they
 
 
 ## Implementation notes
-- On key generation, the API will prefix the entire token and provide that back to admin
-- Admin will provide the prefixed key back to the user
-- No changes are required to support old keys
+- API will be responsible to add the prefix and later to validate it:
+   - On key creation: prefix entire token and return to admin
+   - On api requests: prefix validation (once we enable it)
+   - Note: the actual prefix value will not be stored in the database
+- Admin will provide api key details to the user:
+  - On key creation: provide the prefixed key back to the user
+- No changes are required to continue to support old keys
 - After grace period, validation will be implemented to ensure all keys used to call API contain the prefix value 
 
 ## Additional considerations

--- a/records/2022-07-20.security.prefix-api-token.md
+++ b/records/2022-07-20.security.prefix-api-token.md
@@ -1,0 +1,38 @@
+# TITLE
+
+Date: 2022-07-20
+
+## Status
+
+**DRAFT**
+
+## Context
+
+The mishandling of application secrets has lead to many security incidents in companies big and small. Given the inherent risk in how users store these secrets, it is important that we provide mechanisms to protect our users from doing so improperly.  Taking a cue from [Github](https://github.blog/2021-04-05-behind-githubs-new-authentication-token-formats/), [Slack](https://api.slack.com/authentication/token-types), and [Stripe](https://stripe.com/docs/api/authentication), we see that token prefixes are an effective technique to help us ensure our tokens don't end up in public repositories.
+
+By combining a known prefix with Github's [secret scanning program](https://docs.github.com/en/developers/overview/secret-scanning-partner-program), we can be alerted if one of our users mistakenly stores their API keys in the open and we can take action.
+
+## Options
+
+- Add a known prefix to our API keys in order to be able to easily identify them.
+- Register with Github's secret scanning program and create an endpoint for them to report issues back to us
+
+### After grace period
+- Enforce a rule that ensures all API keys contain our prefix
+
+## Additional considerations
+
+### Supporting older keys
+We want to be able to support previous API keys for a certain time period and there should be nothing additional we need to do for that (provided we dont remove old keys). But, in the future, we may want to enforce that all keys have the prefix after a certain time, i.e. within 6 months, 9 months, etc.  This would involve us enumerating old keys, contacting users and invalidating the keys once we know they have new ones.
+
+### Verifying API keys
+Currently, API ignores everything but the right-most characters of an API key.  This will need to be updated in order to verify the existence of the prefix.
+
+
+## Decision
+
+_TODO: Describe the way forward._
+
+## Consequences
+
+_TODO: Describe foreseen and felt consequences of the decision (possible after 1-3 months)._


### PR DESCRIPTION
# Summary | Résumé
ADR to document implementing API token prefixes, as well as mechanisms to enforce them and verify they don't land in public repos.