### PR TITLE
fix: update ADR to reflect change to pgAudit

### DIFF
--- a/records/2024-04-05.database-activity-logging.md
+++ b/records/2024-04-05.database-activity-logging.md
@@ -4,7 +4,7 @@ Date: 2024-04-05
 
 ## Status
 
-**APPROVED**
+**IN REVIEW**
 
 ## Context
 
@@ -32,7 +32,7 @@ The proposed solution for GC Notify would be to create an asynchronous activity 
 ![Database activity stream architecture](./diagrams/2024-04-05.database-activity-logging/activity-stream-arch.png)
 _Figure 1: [Database activity stream architecture](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/DBActivityStreams.Overview.html#DBActivityStreams.Overview.how-they-work)_
 
-In order to respect Notify's privacy policy, the S3 activity log for application queries would be deleted after 4 days. However, activity logs for queries run manually by Notify team members would be stored in a separate S3 folder with a longer retention period (1+ years).
+In order to respect Notify's privacy policy, the S3 activity log for application queries would be deleted after 3 days. However, activity logs for queries run manually by Notify team members would be stored in a separate S3 folder with a longer retention period (1+ years).
 
 ### Option 2: PostgreSQL audit extension (pgAudit)
 
@@ -40,9 +40,8 @@ The pgAudit extension uses the built-in PostgresSQL logging infrastructure and e
 
 The proposed auditing solution using pgAudit would be to:
 
-1. enable pgAudit using the database cluster's parameter group,
-1. install and configure the pgAudit extension, and
-1. publish audit logs to a CloudWatch log group with a 4 day expiration setting.
+1. enable pgAudit using the database cluster's parameter group, and
+1. publish audit logs to a CloudWatch log group with a 3 day expiration setting.
 
 When using pgAudit, it is important to be [mindful of which queries are being logged](https://github.com/pgaudit/pgaudit/blob/master/README.md#usage-considerations).  This is because the audit logs are stored on the database instance and can lead to disk space exhaustion and performance issues if too much data is logged.
 
@@ -52,7 +51,7 @@ Database performance impact, cost and customization of which events are logged a
 
 ## Decision
 
-Based on the above, the decision has been made to use database activity streams.  This has the following benefits:
+Based on the above, the decision was made to use database activity streams because the following:
 
 1. Negligible impact to database performance.
 1. S3 audit log storage costs are low.
@@ -60,15 +59,17 @@ Based on the above, the decision has been made to use database activity streams.
 1. No requirement to install database extensions or modify the database configuration.
 1. High degree of customization around which database activity events are stored.
 
+However, after monitoring the activity stream in Staging for a week, it became clear that the activity stream KMS decryption costs were quite high.  It was averaging $10/day and would be higher in Production due to the heavier load on the database.
+
+Additionally, during testing of `pgAudit`, it was discovered that the extension install and log file cleanup are handled automatically by Aurora clusters.  As such, the decision has been made to proceed with `pgAudit` as the tool to audit database activity.
+
 ## Consequences
 
 ### Increased cost
-The activity logs in S3, Kinesis Firehose data ingestion and KMS key activity will raise costs.  Monitoring will be needed to ensure the increased costs are reasonable.
+Data ingestion to the `pgAudit` CloudWatch log group will raise costs.  This will need to be monitored to make sure the cost is reasonable.
 
 ### Performance impact to the database
-Although asynchronous activity streams should have very little impact to the database performance, this will need to be tested before deploying to production.
+Enabling `pgAudit` will cause more log data to be written to the PostgreSQL log framework on each instance.  As a result this will increase the disk space, memory and CPU usage of the instances.  This will need to be performance tested in Staging before deploying to Production to ensure that Notify's performance is not impacted.
 
 ### Unsanitized query data appearing in plaintext
-The activity stream events contain all database queries.  This could include sensitive, unsanitized query data that will be stored in plaintext in the S3 bucket.  This is similar to the risk that currently exists with Blazer, but it introduces a new location for the data.  
-
-This risk can be mitigated by ensuring access to the S3 activity log bucket is restricted and/or adding query sanitizing to the Kinesis Firehose's processing Lambda function.  
+The `pgAudit` query logs contain all database queries.  This could include sensitive, unsanitized query data that will be stored in plaintext in the CloudWatch log group.  This is similar to the risk that currently exists with Blazer, but it introduces a new location for the data.  


### PR DESCRIPTION
# Summary
Update the database audit logging ADR with details around why we have switched to pgAudit.

[👁️ Rendered view](https://github.com/cds-snc/notification-adr/blob/fix/database-audit/records/2024-04-05.database-activity-logging.md)

# Related
- https://github.com/cds-snc/platform-core-services/issues/508